### PR TITLE
Adding test for PintPulsar

### DIFF
--- a/enterprise/signals/deterministic_signals.py
+++ b/enterprise/signals/deterministic_signals.py
@@ -168,11 +168,6 @@ def PhysicalEphemerisSignal(
         signal_id = "phys_ephem_" + name if name else "phys_ephem"
 
         def __init__(self, psr):
-            # not available for PINT yet
-            if isinstance(psr, pulsar.PintPulsar):
-                msg = "Physical Ephemeris model is not compatible with PINT "
-                msg += "at this time."
-                raise NotImplementedError(msg)
 
             super(PhysicalEphemerisSignal, self).__init__(psr)
 

--- a/tests/test_deterministic_signals.py
+++ b/tests/test_deterministic_signals.py
@@ -179,13 +179,56 @@ class TestDeterministicSignals(unittest.TestCase):
 
         # test PINT exception raising
         elif isinstance(self.psr, enterprise.pulsar.PintPulsar):
-            with self.assertRaises(NotImplementedError) as context:
-                eph1 = deterministic_signals.PhysicalEphemerisSignal(sat_orb_elements=True)
-                e1 = eph1(self.psr)
+            # define signals with and without epoch TOAs
+            eph1 = deterministic_signals.PhysicalEphemerisSignal(sat_orb_elements=True, model="orbel")
+            eph2 = deterministic_signals.PhysicalEphemerisSignal(
+                sat_orb_elements=True, use_epoch_toas=False, model="orbel"
+            )
 
-                msg = "Physical Ephemeris model is not compatible with PINT "
-                msg += "at this time."
-                self.assertEqual(msg, str(context.exception))
+            # initialize signals
+            e1, e2 = eph1(self.psr), eph2(self.psr)
+
+            # set parameters
+            params = {
+                "d_jupiter_mass": -8.561198198000628e-12,
+                "d_neptune_mass": 1.0251757860647059e-11,
+                "d_saturn_mass": 6.22114376130324e-12,
+                "d_uranus_mass": -2.1157536169469958e-10,
+                "frame_drift_rate": 2.874659280396648e-10,
+                "jup_orb_elements": np.array(
+                    [0.04140015, -0.03422412, 0.01165894, -0.03525219, -0.00406852, 0.0421522]
+                ),
+                "sat_orb_elements": np.array(
+                    [-0.39701798, -0.13322608, -0.05025925, 0.36331171, -0.17080321, 0.25093799]
+                ),
+            }
+
+            # test against waveform and compare non-epoch and epoch TOA results
+            d1 = e1.get_delay(params=params)
+            d2 = e2.get_delay(params=params)
+
+            (jup_mjd, jup_orbel, sat_orbel) = utils.get_planet_orbital_elements("orbel")
+
+            d3 = utils.physical_ephem_delay(
+                self.psr.toas,
+                self.psr.planetssb,
+                self.psr.pos_t,
+                times=jup_mjd,
+                jup_orbit=jup_orbel,
+                sat_orbit=sat_orbel,
+                **params,
+            )
+
+            msg1 = "Signal delay does not match function delay"
+            assert np.allclose(d1, d3, rtol=1e-10), msg1
+            msg2 = "epoch-TOA delay does not match full TOA delay"
+            assert np.allclose(d1, d2, rtol=1e-10), msg2
+
+            # test against pre-computed wafeform
+            eph_wf = np.load(datadir + "/phys_ephem_1855_test.npy")
+            msg = "Ephemeris delay does not match pre-computed values"
+            assert np.allclose(d1, eph_wf, rtol=1e-10), msg
+
 
 
 class TestDeterministicSignalsPint(TestDeterministicSignals):


### PR DESCRIPTION
@AaronDJohnson I've added in the test for the PintPulsar object. It doesn't pass, but if you accept this pull request then we can get to the next stage of debugging. It looks like there is a precomputed value for the ephemeris perturbations that is being checked against. Since the Pint values for the SSB vectors are so different I don't expect things to match perfectly, but I don't know enough about the ephemeris modeling to know what we should do. @vallis might be able to help, but it would be instructive to merge this. Then it will get tested and others can see where it fails. 